### PR TITLE
Update dev docs (and add pre-commit setup)

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,18 @@
+name: precommit
+
+on:
+  pull_request:
+  push:
+    branches:
+      - master
+  schedule:
+    # run once a week on early monday mornings
+    - cron: '22 2 * * 1'
+
+jobs:
+  pre-commit:
+    runs-on: ubuntu-20.04
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/setup-python@v2
+      - uses: pre-commit/action@v2.0.0

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,22 @@
+---
+repos:
+  - repo: https://github.com/pre-commit/pre-commit-hooks.git
+    rev: v3.4.0
+    hooks:
+      - id: check-added-large-files
+      - id: check-byte-order-marker
+      - id: check-case-conflict
+      - id: check-executables-have-shebangs
+      - id: check-merge-conflict
+      - id: check-yaml
+      - id: debug-statements
+      - id: end-of-file-fixer
+      - id: mixed-line-ending
+      - id: requirements-txt-fixer
+      - id: trailing-whitespace
+
+  - repo: https://github.com/ansible/ansible-lint.git
+    rev: v4.3.7
+    hooks:
+      - id: ansible-lint
+        files: \.(yaml|yml)$

--- a/LICENSE
+++ b/LICENSE
@@ -1,4 +1,4 @@
-Copyright (c) 2020, Caktus Consulting Group, LLC
+Copyright (c) 2020-1, Caktus Consulting Group, LLC
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without modification,

--- a/README.rst
+++ b/README.rst
@@ -106,9 +106,10 @@ How do I add this role to my project
 
 #. Review ``defaults/main.yml`` in this repo to see other variables that you can override.
 
+#. See the next section for the commands to deploy this role to your cluster.
 
-Usage
------
+How do I deploy this role to my cluster
+---------------------------------------
 
 Once you have configured the role as described above (or any time you need to make a
 change to the configuration), you can deploy this to your kubernetes cluster.
@@ -125,3 +126,18 @@ change to the configuration), you can deploy this to your kubernetes cluster.
 
      cd deploy/
      ansible-playbook deploy-hosting-services.yaml -vv
+
+
+Maintainer information
+----------------------
+
+If you are working on the role itself (rather than just using the role), make sure to
+set up a Python 3 virtualenv and then set up pre-commit:
+
+.. code-block:: sh
+
+   pip install -Ur requirements.txt
+   pre-commit install  # <- only needs to be done once
+
+The pre-commit tasks will run on each commit locally, and will run in Github Actions for
+each pull request.

--- a/README.rst
+++ b/README.rst
@@ -1,6 +1,11 @@
 caktus.k8s-hosting-services
 ===========================
 
+.. |master-status| image::
+    https://github.com/caktus/ansible-role-k8s-hosting-services/workflows/test/badge.svg?branch=master
+    :alt: Build Status
+    :target: https://github.com/caktus/ansible-role-k8s-hosting-services/actions?query=branch%3Amaster
+
 An Ansible role to allow Caktus Kubernetes projects to take advantage of common
 Caktus-provided services. These include:
 

--- a/README.rst
+++ b/README.rst
@@ -1,10 +1,9 @@
 caktus.k8s-hosting-services
 ===========================
 
-.. |master-status| image::
-    https://github.com/caktus/ansible-role-k8s-hosting-services/workflows/test/badge.svg?branch=master
-    :alt: Build Status
-    :target: https://github.com/caktus/ansible-role-k8s-hosting-services/actions?query=branch%3Amaster
+.. sidebar:: Build Status
+
+   :master: |master-status|
 
 An Ansible role to allow Caktus Kubernetes projects to take advantage of common
 Caktus-provided services. These include:
@@ -146,3 +145,8 @@ set up a Python 3 virtualenv and then set up pre-commit:
 
 The pre-commit tasks will run on each commit locally, and will run in Github Actions for
 each pull request.
+
+.. |master-status| image::
+    https://github.com/caktus/ansible-role-k8s-hosting-services/workflows/test/badge.svg?branch=master
+    :alt: Build Status
+    :target: https://github.com/caktus/ansible-role-k8s-hosting-services/actions?query=branch%3Amaster

--- a/README.rst
+++ b/README.rst
@@ -1,11 +1,14 @@
 caktus.k8s-hosting-services
 ===========================
 
-An Ansible role to allow Caktus Kubernetes projects to easily back up their Postgres
-database to the proper Caktus Hosting Services AWS S3 bucket.
+An Ansible role to allow Caktus Kubernetes projects to take advantage of common
+Caktus-provided services. These include:
+
+* backing up the Postgres database to the proper Caktus Hosting Services AWS S3 bucket.
+* More coming soon! (Papertrail, NewRelic infra, etc)
 
 License
-~~~~~~~~~~~~~~~~~~~~~~
+-------
 
 This Ansible role is released under the BSD License.  See the `LICENSE
 <https://github.com/caktus/ansible-role-aws-web-stacks/blob/master/LICENSE>`_
@@ -15,14 +18,8 @@ Development sponsored by `Caktus Consulting Group, LLC
 <http://www.caktusgroup.com/services>`_.
 
 
-Requirements
-~~~~~~~~~~~~~~~~~~~~~~
-
-* ``pip install openshift kubernetes-validate``
-
-
-Installation and Configuration
-------------------------------
+How do I add this role to my project
+------------------------------------
 
 1. Add to your ``requirements.yaml``:
 
@@ -63,7 +60,10 @@ Installation and Configuration
    #. The hosting services BACKUP_HEALTHCHECK_URL.
 
    The first should be obtained from your project's configuration and the other two
-   items will be given to you by the Caktus TS team.
+   items will be given to you by the Caktus TS team. (TS Team: AWS_SECRET_ACCESS_KEY is
+   in the LastPass shared entry: "Caktus Website Hosting Services k8s secrets" and you
+   should generate a new healtcheck url at healtchecks.io and provide that to the
+   developer for their BACKUP_HEALTHCHECK_URL variable)
 
    Use ansible-vault to encrypt them:
 
@@ -80,6 +80,9 @@ Installation and Configuration
       k8s_hosting_services_aws_secret_access_key: "<... secret from ansible-vault output ...>"
       k8s_hosting_services_database_url: "<... secret from ansible-vault output ...>"
       k8s_hosting_services_healthcheck_url: "<... secret from ansible-vault output ...>"
+
+   ``k8s_hosting_services_project_name`` will be the directory in S3 under which these
+   backups will be stored.
 
 #. By default, this role will run backups on a daily, weekly, monthly and yearly
    schedule. If you don't need all of those, or if you need a custom schedule, then
@@ -107,8 +110,8 @@ Installation and Configuration
 Usage
 -----
 
-Once you have configured the role as described above, you can deploy this to your
-kubernetes cluster.
+Once you have configured the role as described above (or any time you need to make a
+change to the configuration), you can deploy this to your kubernetes cluster.
 
 * Using invoke-kubesae:
 

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -1,7 +1,12 @@
 ---
 galaxy_info:
+  role_name: k8s_hosting_services
   author: Caktus Consulting Group, LLC
   description: Backup database instances on Kubernetes
   company: Caktus Consulting Group, LLC
   license: BSD
+  min_ansible_version: 2.9
+  platforms:
+    - name: Ubuntu
+      versions: all
 dependencies: []

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,1 @@
+pre-commit


### PR DESCRIPTION
The first commit adds documentation updates (mainly for developers adding this role to their project, but also with a couple hints to the TS team about where to find the necessary secrets).

The second commit adds a pre-commit config and Github Action workflow, which runs [ansible-lint](https://github.com/ansible-community/ansible-lint).