### PR TITLE
[ISSUE-1] Fix cron definition. Remove extraneous quote

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -159,7 +159,7 @@ How do I add this role to my project
         - label: yearly
           schedule: "@yearly"
         - label: every2hours
-          schedule: ""* */2 * * *"
+          schedule: "0 */2 * * *"
 
 #. Review ``defaults/main.yml`` in this repo to see other variables that you can override.
 


### PR DESCRIPTION
Changes the README to fix a bug in example cron definition.