### PR TITLE
Optional support for SOURCE_AWS_CA_BUNDLE and SOURCE_AWS_NO_VERIFY_SSL environment variables

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,4 @@
 .vscode
 .python-version
+.envrc
+.direnv

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -14,9 +14,3 @@ repos:
       - id: mixed-line-ending
       - id: requirements-txt-fixer
       - id: trailing-whitespace
-
-  - repo: https://github.com/ansible/ansible-lint.git
-    rev: v4.3.7
-    hooks:
-      - id: ansible-lint
-        files: \.(yaml|yml)$

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -5,6 +5,7 @@ caktus.k8s-hosting-services Releases
 v0.7.0 on 2022-04-06
 ~~~~~~~~~~~~~~~~~~~~
 * Add optional support for `SOURCE_AWS_CA_BUNDLE` and `SOURCE_AWS_NO_VERIFY_SSL` environment variables
+* Default to `0.4.0-postgres12` Docker image tag
 
 
 v0.6.1 on 2022-03-01

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -2,6 +2,16 @@ caktus.k8s-hosting-services Releases
 ====================================
 
 
+v0.7.0 on 2022-04-06
+~~~~~~~~~~~~~~~~~~~~
+* Add optional support for `SOURCE_AWS_CA_BUNDLE` and `SOURCE_AWS_NO_VERIFY_SSL` environment variables
+
+
+v0.6.1 on 2022-03-01
+~~~~~~~~~~~~~~~~~~~~
+* Set default tag to 0.3.0-postgres12
+
+
 v0.6.0 on 2022-02-24
 ~~~~~~~~~~~~~~~~~~~~
 * Add S3 bucket backup support

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -39,9 +39,9 @@ k8s_hosting_services_environment:
   SOURCE_AWS_REGION: "{{ k8s_hosting_services_backup_s3_source_region }}"
   SOURCE_AWS_ACCESS_KEY_ID: "{{ k8s_hosting_services_backup_s3_source_aws_access_key }}"
   SOURCE_AWS_SECRET_ACCESS_KEY: "{{ k8s_hosting_services_backup_s3_source_aws_secret_access_key }}"
-  SOURCE_AWS_ENDPOINT_URL: "{{ k8s_hosting_services_backup_s3_source_endpoint_url | default(omit) }}"
-  SOURCE_AWS_CA_BUNDLE: "{{ k8s_hosting_services_backup_s3_source_ca_bundle | default(omit) }}"
-  SOURCE_AWS_NO_VERIFY_SSL: "{{ k8s_hosting_services_backup_s3_source_no_verify_ssl | default(omit) }}"
+  SOURCE_AWS_ENDPOINT_URL: "{{ k8s_hosting_services_backup_s3_source_endpoint_url | default('') }}"
+  SOURCE_AWS_CA_BUNDLE: "{{ k8s_hosting_services_backup_s3_source_ca_bundle | default('') }}"
+  SOURCE_AWS_NO_VERIFY_SSL: "{{ k8s_hosting_services_backup_s3_source_no_verify_ssl | default('') }}"
 k8s_hosting_services_image: ghcr.io/caktus/k8s-caktus-backup
 k8s_hosting_services_image_tag: 0.3.0-postgres12
 k8s_hosting_services_image_pull_policy: IfNotPresent

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -43,7 +43,7 @@ k8s_hosting_services_environment:
   SOURCE_AWS_CA_BUNDLE: "{{ k8s_hosting_services_backup_s3_source_ca_bundle | default('') }}"
   SOURCE_AWS_NO_VERIFY_SSL: "{{ k8s_hosting_services_backup_s3_source_no_verify_ssl | default('') }}"
 k8s_hosting_services_image: ghcr.io/caktus/k8s-caktus-backup
-k8s_hosting_services_image_tag: 0.3.0-postgres12
+k8s_hosting_services_image_tag: 0.4.0-postgres12
 k8s_hosting_services_image_pull_policy: IfNotPresent
 k8s_hosting_services_resources:
   requests:

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -39,7 +39,9 @@ k8s_hosting_services_environment:
   SOURCE_AWS_REGION: "{{ k8s_hosting_services_backup_s3_source_region }}"
   SOURCE_AWS_ACCESS_KEY_ID: "{{ k8s_hosting_services_backup_s3_source_aws_access_key }}"
   SOURCE_AWS_SECRET_ACCESS_KEY: "{{ k8s_hosting_services_backup_s3_source_aws_secret_access_key }}"
-  SOURCE_AWS_ENDPOINT_URL: "{{ k8s_hosting_services_backup_s3_source_endpoint_url }}"
+  SOURCE_AWS_ENDPOINT_URL: "{{ k8s_hosting_services_backup_s3_source_endpoint_url | default(omit) }}"
+  SOURCE_AWS_CA_BUNDLE: "{{ k8s_hosting_services_backup_s3_source_ca_bundle | default(omit) }}"
+  SOURCE_AWS_NO_VERIFY_SSL: "{{ k8s_hosting_services_backup_s3_source_no_verify_ssl | default(omit) }}"
 k8s_hosting_services_image: ghcr.io/caktus/k8s-caktus-backup
 k8s_hosting_services_image_tag: 0.3.0-postgres12
 k8s_hosting_services_image_pull_policy: IfNotPresent


### PR DESCRIPTION
* Add optional support for `SOURCE_AWS_CA_BUNDLE` and `SOURCE_AWS_NO_VERIFY_SSL` environment variables
* Default to `0.4.0-postgres12` Docker image tag