### PR TITLE
Use kubernetes.core.k8s everywhere

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,6 +1,11 @@
 caktus.k8s-hosting-services Releases
 ====================================
 
+v0.10.0 on 2023-02-14
+~~~~~~~~~~~~~~~~~~~~~
+* Use full ``kubernetes.core.k8s`` module references to support newer Ansible versions (#22)
+
+
 v0.9.0 on 2022-12-09
 ~~~~~~~~~~~~~~~~~~~~
 * Update New Relic configuration keys to match latest Helm chart keys (#20)

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -1,7 +1,7 @@
 ---
 
 - name: Create namespace for Caktus Hosting Services
-  k8s:
+  kubernetes.core.k8s:
     context: "{{ k8s_context|mandatory }}"
     kubeconfig: "{{ k8s_kubeconfig }}"
     state: "{{ k8s_hosting_services_enabled | ternary('present', 'absent') }}"
@@ -16,7 +16,7 @@
         name: "{{ k8s_hosting_services_namespace }}"
 
 - name: Create/update templates in Kubernetes
-  k8s:
+  kubernetes.core.k8s:
     context: "{{ k8s_context|mandatory }}"
     kubeconfig: "{{ k8s_kubeconfig }}"
     state: "{{ k8s_hosting_services_enabled | ternary('present', 'absent') }}"

--- a/tasks/monitoring.yml
+++ b/tasks/monitoring.yml
@@ -48,7 +48,7 @@
   when: k8s_hosting_services_enabled
 
 - name: Add New Relic Helm chart
-  community.kubernetes.helm:
+  kubernetes.core.helm:
     context: "{{ k8s_context|mandatory }}"
     kubeconfig: "{{ k8s_kubeconfig }}"
     chart_repo_url: https://helm-charts.newrelic.com

--- a/tasks/monitoring.yml
+++ b/tasks/monitoring.yml
@@ -1,5 +1,5 @@
 - name: Create namespace for Papertrail
-  k8s:
+  kubernetes.core.k8s:
     context: "{{ k8s_context|mandatory }}"
     kubeconfig: "{{ k8s_kubeconfig }}"
     state: present
@@ -16,7 +16,7 @@
   when: k8s_papertrail_logspout_enabled
 
 - name: Deploy Papertrail logspout
-  k8s:
+  kubernetes.core.k8s:
     context: "{{ k8s_context|mandatory }}"
     kubeconfig: "{{ k8s_kubeconfig }}"
     state: "{{ k8s_papertrail_logspout_enabled | ternary('present', 'absent') }}"
@@ -31,7 +31,7 @@
   tags: [papertrail]
 
 - name: Create namespace for New Relic
-  k8s:
+  kubernetes.core.k8s:
     context: "{{ k8s_context|mandatory }}"
     kubeconfig: "{{ k8s_kubeconfig }}"
     state: present


### PR DESCRIPTION
* Switch `community.kubernetes.helm`, which breaks on newer Ansible versions, to `kubernetes.core.k8s`
* Use full `kubernetes.core.k8s` path elsewhere