### PR TITLE
Ansible 6.x support

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -1,7 +1,7 @@
 ---
 
 - name: Create namespace for Caktus Hosting Services
-  k8s:
+  kubernetes.core.k8s:
     context: "{{ k8s_context|mandatory }}"
     kubeconfig: "{{ k8s_kubeconfig }}"
     state: "{{ k8s_hosting_services_enabled | ternary('present', 'absent') }}"
@@ -16,7 +16,7 @@
         name: "{{ k8s_hosting_services_namespace }}"
 
 - name: Create/update templates in Kubernetes
-  k8s:
+  kubernetes.core.k8s:
     context: "{{ k8s_context|mandatory }}"
     kubeconfig: "{{ k8s_kubeconfig }}"
     state: "{{ k8s_hosting_services_enabled | ternary('present', 'absent') }}"

--- a/tasks/monitoring.yml
+++ b/tasks/monitoring.yml
@@ -1,5 +1,5 @@
 - name: Create namespace for Papertrail
-  k8s:
+  kubernetes.core.k8s:
     context: "{{ k8s_context|mandatory }}"
     kubeconfig: "{{ k8s_kubeconfig }}"
     state: present
@@ -16,7 +16,7 @@
   when: k8s_papertrail_logspout_enabled
 
 - name: Deploy Papertrail logspout
-  k8s:
+  kubernetes.core.k8s:
     context: "{{ k8s_context|mandatory }}"
     kubeconfig: "{{ k8s_kubeconfig }}"
     state: "{{ k8s_papertrail_logspout_enabled | ternary('present', 'absent') }}"
@@ -31,7 +31,7 @@
   tags: [papertrail]
 
 - name: Create namespace for New Relic
-  k8s:
+  kubernetes.core.k8s:
     context: "{{ k8s_context|mandatory }}"
     kubeconfig: "{{ k8s_kubeconfig }}"
     state: present
@@ -48,7 +48,7 @@
   when: k8s_hosting_services_enabled
 
 - name: Add New Relic Helm chart
-  community.kubernetes.helm:
+  kubernetes.core.helm:
     context: "{{ k8s_context|mandatory }}"
     kubeconfig: "{{ k8s_kubeconfig }}"
     chart_repo_url: https://helm-charts.newrelic.com


### PR DESCRIPTION
* Switch to `kubernetes.core` for Ansible 6.x+ support and use [fully qualified collection names (FQCNs)](https://github.com/ansible-collections/overview/blob/4e7fdd2512a4ec213b1beccef3b58dfb58b0d06e/README.rst#terminology) to be explicit. The `community.kubernetes` collection was renamed to `kubernetes.core` in [v2.0.0 of the kubernetes.core collection](https://github.com/ansible-collections/community.kubernetes/blob/main/CHANGELOG.rst#v2-0-0). Since [Ansible v3.0.0](https://github.com/ansible-community/ansible-build-data/blob/main/3/CHANGELOG-v3.rst#included-collections), both the `kubernetes.core` and `community.kubernetes` namespaced collections were included for convenience. [Ansible v6.0.0](https://github.com/ansible-community/ansible-build-data/blob/f3602822e899015312852bb3e2debe52df109135/6/CHANGELOG-v6.rst#L4281) removed the `community.kubernetes` convenience package.