### PR TITLE
Switch to batch/v1 API version for CronJob

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -2,10 +2,15 @@ caktus.k8s-hosting-services Releases
 ====================================
 
 
+v0.11.0 on 2023-04-25
+~~~~~~~~~~~~~~~~~~~~~
+* Support Kubernetes v1.25 by using the ``batch/v1`` API version for ``CronJob``, available since v1.21.
+
+
 v0.10.0 on 2023-04-25
 ~~~~~~~~~~~~~~~~~~~~~
-* Switch `community.kubernetes.helm`, which breaks on newer Ansible versions, to `kubernetes.core.k8s`
-* Use full `kubernetes.core.k8s` path elsewhere
+* Switch ``community.kubernetes.helm``, which breaks on newer Ansible versions, to ``kubernetes.core.k8s``
+* Use full ``kubernetes.core.k8s`` path elsewhere
 
 
 v0.9.0 on 2022-12-09

--- a/templates/hosting-services/backup-job.yaml.j2
+++ b/templates/hosting-services/backup-job.yaml.j2
@@ -15,7 +15,7 @@ type: Opaque
 stringData: {{ k8s_hosting_services_environment | to_json }}
 {% for crontab in k8s_hosting_services_cron_schedules %}
 ---
-apiVersion: batch/v1beta1
+apiVersion: batch/v1
 kind: CronJob
 metadata:
   namespace: "{{ k8s_hosting_services_namespace }}"


### PR DESCRIPTION
Support Kubernetes v1.25 by using the `batch/v1` API version for `CronJob`, available since v1.21. Notes from the [deprecation guide](https://kubernetes.io/docs/reference/using-api/deprecation-guide/#cronjob-v125):

> The batch/v1beta1 API version of CronJob is no longer served as of v1.25.
> 
> * Migrate manifests and API clients to use the batch/v1 API version, available since v1.21.
> * All existing persisted objects are accessible via the new API
> * No notable changes